### PR TITLE
Feature: Power cycling for PoE ports

### DIFF
--- a/poe_cycle.go
+++ b/poe_cycle.go
@@ -41,16 +41,9 @@ func (poe *PoeCyclePowerCommand) Run(args *GlobalOptions) error {
 		return errors.New(result)
 	}
 
-	var changedPorts []PoePortSetting
 	settings, err = requestPoeConfiguration(args, poe.Address, poeExt)
 
-	for _, configuredPort := range poe.Ports {
-		for _, portSetting := range settings {
-			if int(portSetting.PortIndex) == configuredPort {
-				changedPorts = append(changedPorts, portSetting)
-			}
-		}
-	}
+	changedPorts := collectChangedPortConfiguration(poe.Ports, settings)
 
 	prettyPrintSettings(args.OutputFormat, changedPorts)
 

--- a/poe_cycle.go
+++ b/poe_cycle.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+type PoeCyclePowerCommand struct {
+	Address string `required:"" help:"the Netgear switch's IP address or host name to connect to" short:"a"`
+	Ports   []int  `required:"" help:"port number (starting with 1), use multiple times for cycling multiple ports at once" short:"p" name:"port"`
+}
+
+func (poe *PoeCyclePowerCommand) Run(args *GlobalOptions) error {
+	poeExt := &PoeExt{}
+
+	settings, err := requestPoeConfiguration(args, poe.Address, poeExt)
+	if err != nil {
+		return err
+	}
+
+	poeSettings := url.Values{
+		"hash":   {poeExt.Hash},
+		"ACTION": {"Reset"},
+	}
+
+	for _, switchPort := range poe.Ports {
+		if switchPort > len(settings) || switchPort < 1 {
+			return errors.New(fmt.Sprintf("given port id %d, doesn't fit in range 1..%d", switchPort, len(settings)))
+		}
+
+		poeSettings.Add(fmt.Sprintf("port%d", switchPort-1), "checked")
+	}
+
+	result, err := requestPoeSettingsUpdate(args, poe.Address, poeSettings.Encode())
+	if err != nil {
+		return err
+	}
+
+	if result != "SUCCESS" {
+		return errors.New(result)
+	}
+
+	var changedPorts []PoePortSetting
+	settings, err = requestPoeConfiguration(args, poe.Address, poeExt)
+
+	for _, configuredPort := range poe.Ports {
+		for _, portSetting := range settings {
+			if int(portSetting.PortIndex) == configuredPort {
+				changedPorts = append(changedPorts, portSetting)
+			}
+		}
+	}
+
+	prettyPrintSettings(args.OutputFormat, changedPorts)
+
+	return err
+}

--- a/poe_set_port.go
+++ b/poe_set_port.go
@@ -112,10 +112,17 @@ func (poe *PoeSetPowerCommand) Run(args *GlobalOptions) error {
 		}
 	}
 
-	var changedPorts []PoePortSetting
 	settings, err = requestPoeConfiguration(args, poe.Address, poeExt)
 
-	for _, configuredPort := range poe.Ports {
+	changedPorts := collectChangedPortConfiguration(poe.Ports, settings)
+
+	prettyPrintSettings(args.OutputFormat, changedPorts)
+
+	return err
+}
+
+func collectChangedPortConfiguration(poePorts []int, settings []PoePortSetting) (changedPorts []PoePortSetting) {
+	for _, configuredPort := range poePorts {
 		for _, portSetting := range settings {
 			if int(portSetting.PortIndex) == configuredPort {
 				changedPorts = append(changedPorts, portSetting)
@@ -123,9 +130,7 @@ func (poe *PoeSetPowerCommand) Run(args *GlobalOptions) error {
 		}
 	}
 
-	prettyPrintSettings(args.OutputFormat, changedPorts)
-
-	return err
+	return changedPorts
 }
 
 func requestPoeConfiguration(args *GlobalOptions, host string, poeExt *PoeExt) ([]PoePortSetting, error) {

--- a/poe_status.go
+++ b/poe_status.go
@@ -24,6 +24,7 @@ type PoeCommand struct {
 	PoeStatusCommand       PoeStatusCommand       `cmd:"" name:"status" help:"show current PoE status for all ports" default:"1"`
 	PoeShowSettingsCommand PoeShowSettingsCommand `cmd:"" name:"settings" help:"show current PoE settings for all ports"`
 	PoeSetPowerCommand     PoeSetPowerCommand     `cmd:"" name:"set" help:"set new PoE settings per each PORT number"`
+	PoeCyclePowerCommand   PoeCyclePowerCommand   `cmd:"" name:"cycle" help:"power cycle one or more PoE ports"`
 }
 
 type PoeStatusCommand struct {


### PR DESCRIPTION
Hi Martin,

This pull, if merged, will add PoE power cycling functionality to `ntgrrc`.

Multiple ports can be specified for cycling, similar to how PoE settings
are currently manipulated with the `-p` parameter.

    poe cycle -p 8 -p 7 -a 203.0.113.5

Similar to the web interface, cycling a PoE disabled port has no effect.

One thing for your consideration: the output on success only indicates the port(s) that were submitted for power cycling and their state afterwards (similar to the `set` feature output). There is no explicit indication of a port being cycled and I could not find an elegant way to introduce it into the output.

At the same time however, it may be an unnecessary element since the port(s) state is shown afterwards.

As before, please let me know if there are any parts that should be reworked, I appreciate your review.