### PR TITLE
token directory improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 
 # ntgrrc (Netgear Remote Control) CHANGELOG
 
+## v0.7.2
+
+* using "-v" over "-d" for verbose output
+* using OS specific tmp directory to store login token (see #17) 
+
+----
+
 ## v0.7.1
 
 * add prompt for a password if not specified via command line argument (see #9)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Usage: ntgrrc <command>
 Flags:
   -h, --help                  Show context-sensitive help.
       --help-all              advanced/full help
-  -d, --verbose               verbose log messages
+  -v, --verbose               verbose log messages
   -q, --quiet                 no log messages
   -f, --output-format="md"    what output format to use [md, json]
 

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ type GlobalOptions struct {
 
 var cli struct {
 	HelpAll      HelpAllFlag  `help:"advanced/full help"`
-	Verbose      bool         `help:"verbose log messages" short:"d"`
+	Verbose      bool         `help:"verbose log messages" short:"v"`
 	Quiet        bool         `help:"no log messages" short:"q"`
 	OutputFormat OutputFormat `help:"what output format to use [md, json]" enum:"md,json" default:"md" short:"f"`
 

--- a/token.go
+++ b/token.go
@@ -45,9 +45,6 @@ func ensureConfigPathExists() error {
 }
 
 func dotConfigDirName() string {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		panic(err)
-	}
-	return filepath.Join(homeDir, ".config", "ntgrrc")
+	tempDir := os.TempDir()
+	return filepath.Join(tempDir, ".config", "ntgrrc")
 }


### PR DESCRIPTION
This PR addresses #16 allthough it doesn't add the feature of a configurable token location and rather uses the `/tmp` directory which is OS specific.

Iam not sure if this will work in every scenario but atleast it will help me and the most know use case of `ro` filesystems where just the `/tmp` is writable.