### PR TITLE
Add support for "Longer Detection Time"

### DIFF
--- a/poe_set_port_test.go
+++ b/poe_set_port_test.go
@@ -29,7 +29,7 @@ func TestFindMaxPowerLimit(t *testing.T) {
 
 func TestCompareSettingsUnknown(t *testing.T) {
 
-	for _, setting := range []Setting{PortPrio, PwrMode, LimitType, DetecType} {
+	for _, setting := range []Setting{PortPrio, PwrMode, LimitType, DetecType, LongerDetect} {
 		setting, _ := compareSettings(setting, "defaultValue", "newValue", poeExt)
 		then.AssertThat(t, setting, is.EqualTo("unknown").Reason("when providing a value that does not exist, return unknown to the caller"))
 	}
@@ -139,6 +139,33 @@ func TestCompareDetecType(t *testing.T) {
 	setting, err = compareSettings(DetecType, "1", "", poeExt)
 	then.AssertThat(t, err, is.Nil())
 	then.AssertThat(t, setting, is.EqualTo("1").Reason("maintain the prior value when nothing new is specified"))
+}
+
+func TestCompareLongerDetect(t *testing.T) {
+
+	setting, err := compareSettings(LongerDetect, "Get Value Fault", "disable", poeExt)
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, setting, is.EqualTo("2").Reason("allow user to change the longer detection time to Disable from Get Value Fault"))
+
+	setting, err = compareSettings(LongerDetect, "Get Value Fault", "enable", poeExt)
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, setting, is.EqualTo("3").Reason("allow user to change the longer detection time to Enable from Get Value Fault"))
+
+	setting, err = compareSettings(LongerDetect, "enable", "disable", poeExt)
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, setting, is.EqualTo("2").Reason("allow user to change the longer detection time to Disable"))
+
+	setting, err = compareSettings(LongerDetect, "disable", "enable", poeExt)
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, setting, is.EqualTo("3").Reason("allow user to change the longer detection time to Enable"))
+
+	setting, err = compareSettings(LongerDetect, "enable", "", poeExt)
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, setting, is.EqualTo("enable").Reason("maintain the same longer detect type when nothing new is specified"))
+
+	setting, err = compareSettings(LongerDetect, "2", "", poeExt)
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, setting, is.EqualTo("2").Reason("maintain the same longer detect type when nothing new is specified"))
 }
 
 //go:embed test-data/PoEPortConfig.cgi.html

--- a/poe_settings.go
+++ b/poe_settings.go
@@ -10,13 +10,14 @@ import (
 )
 
 type PoePortSetting struct {
-	PortIndex int8
-	PortPwr   bool
-	PwrMode   string
-	PortPrio  string
-	LimitType string
-	PwrLimit  string
-	DetecType string
+	PortIndex    int8
+	PortPwr      bool
+	PwrMode      string
+	PortPrio     string
+	LimitType    string
+	PwrLimit     string
+	DetecType    string
+	LongerDetect string
 }
 
 type PoeShowSettingsCommand struct {
@@ -41,7 +42,7 @@ func (poe *PoeShowSettingsCommand) Run(args *GlobalOptions) error {
 }
 
 func prettyPrintSettings(format OutputFormat, settings []PoePortSetting) {
-	var header = []string{"Port ID", "Port Power", "Mode", "Priority", "Limit Type", "Limit (W)", "Type"}
+	var header = []string{"Port ID", "Port Power", "Mode", "Priority", "Limit Type", "Limit (W)", "Type", "Longer Detection Time"}
 	var content [][]string
 	for _, setting := range settings {
 		var row []string
@@ -52,6 +53,7 @@ func prettyPrintSettings(format OutputFormat, settings []PoePortSetting) {
 		row = append(row, bidiMapLookup(setting.LimitType, limitTypeMap))
 		row = append(row, setting.PwrLimit)
 		row = append(row, bidiMapLookup(setting.DetecType, detecTypeMap))
+		row = append(row, bidiMapLookup(setting.LongerDetect, longerDetectMap))
 		content = append(content, row)
 	}
 	switch format {
@@ -102,6 +104,8 @@ func findPortSettingsInHtml(reader io.Reader) ([]PoePortSetting, error) {
 		config.PwrLimit, _ = s.Find("input.pwrLimit").Attr("value")
 
 		config.DetecType, _ = s.Find("input#hidDetecType").Attr("value")
+
+		config.LongerDetect, _ = s.Find("input.longerDetect").Attr("value")
 
 		configs = append(configs, config)
 	})

--- a/poe_value_mappings.go
+++ b/poe_value_mappings.go
@@ -54,3 +54,9 @@ var detecTypeMap = map[string]string{
 	"2": "IEEE 802",
 	"3": "4pt 802.3af + Legacy",
 }
+
+var longerDetectMap = map[string]string{
+	"0": "Get Value Fault",
+	"2": "disable",
+	"3": "enable",
+}

--- a/test-data/GS308EPP/PoEPortConfig.cgi.html
+++ b/test-data/GS308EPP/PoEPortConfig.cgi.html
@@ -117,8 +117,8 @@
 <span class='hid-txt wid-full'>ml975</span>
 </div>
 <div>
-<span class="longerDetectShow">Get Value Fault</span>
-<input type="hidden" class="longerDetect" value="0">
+<span class="longerDetectShow">Disable</span>
+<input type="hidden" class="longerDetect" value="2">
 </div>
 </div>
 <div class="hid_info_cell col-xs-12 col-sm-12">
@@ -188,8 +188,8 @@ EDIT
 <span class='hid-txt wid-full'>ml975</span>
 </div>
 <div>
-<span class="longerDetectShow">Get Value Fault</span>
-<input type="hidden" class="longerDetect" value="0">
+<span class="longerDetectShow">Enable</span>
+<input type="hidden" class="longerDetect" value="3">
 </div>
 </div>
 <div class="hid_info_cell col-xs-12 col-sm-12">
@@ -259,8 +259,8 @@ EDIT
 <span class='hid-txt wid-full'>ml975</span>
 </div>
 <div>
-<span class="longerDetectShow">Get Value Fault</span>
-<input type="hidden" class="longerDetect" value="0">
+<span class="longerDetectShow">Disable</span>
+<input type="hidden" class="longerDetect" value="2">
 </div>
 </div>
 <div class="hid_info_cell col-xs-12 col-sm-12">
@@ -330,8 +330,8 @@ EDIT
 <span class='hid-txt wid-full'>ml975</span>
 </div>
 <div>
-<span class="longerDetectShow">Get Value Fault</span>
-<input type="hidden" class="longerDetect" value="0">
+<span class="longerDetectShow">Enable</span>
+<input type="hidden" class="longerDetect" value="3">
 </div>
 </div>
 <div class="hid_info_cell col-xs-12 col-sm-12">
@@ -401,8 +401,8 @@ EDIT
 <span class='hid-txt wid-full'>ml975</span>
 </div>
 <div>
-<span class="longerDetectShow">Get Value Fault</span>
-<input type="hidden" class="longerDetect" value="0">
+<span class="longerDetectShow">Disable</span>
+<input type="hidden" class="longerDetect" value="2">
 </div>
 </div>
 <div class="hid_info_cell col-xs-12 col-sm-12">
@@ -472,8 +472,8 @@ EDIT
 <span class='hid-txt wid-full'>ml975</span>
 </div>
 <div>
-<span class="longerDetectShow">Get Value Fault</span>
-<input type="hidden" class="longerDetect" value="0">
+<span class="longerDetectShow">Disable</span>
+<input type="hidden" class="longerDetect" value="2">
 </div>
 </div>
 <div class="hid_info_cell col-xs-12 col-sm-12">
@@ -543,8 +543,8 @@ EDIT
 <span class='hid-txt wid-full'>ml975</span>
 </div>
 <div>
-<span class="longerDetectShow">Get Value Fault</span>
-<input type="hidden" class="longerDetect" value="0">
+<span class="longerDetectShow">Disable</span>
+<input type="hidden" class="longerDetect" value="2">
 </div>
 </div>
 <div class="hid_info_cell col-xs-12 col-sm-12">
@@ -565,8 +565,8 @@ EDIT
 <span>802.3at</span>
 <input type="hidden" class="pwrMode" id="hidPwrMode" value="3"></span>
 <span class="pull-right poe-portPwr-width">
-<span class="portPwr">Enable</span>
-<input type="hidden" class="hidPortPwr" id="hidPortPwr" value="1">
+<span class="portPwr">Disable</span>
+<input type="hidden" class="hidPortPwr" id="hidPortPwr" value="0">
 </span>
 <span class="poe_index_li_title poe-port-index">
 <input type="hidden" class="port" value="8">
@@ -614,8 +614,8 @@ EDIT
 <span class='hid-txt wid-full'>ml975</span>
 </div>
 <div>
-<span class="longerDetectShow">Get Value Fault</span>
-<input type="hidden" class="longerDetect" value="0">
+<span class="longerDetectShow">Disable</span>
+<input type="hidden" class="longerDetect" value="2">
 </div>
 </div>
 <div class="hid_info_cell col-xs-12 col-sm-12">

--- a/test-data/GS308EPP/PoEPortConfig.cgi.html
+++ b/test-data/GS308EPP/PoEPortConfig.cgi.html
@@ -68,8 +68,8 @@
 <span>802.3at</span>
 <input type="hidden" class="pwrMode" id="hidPwrMode" value="3"></span>
 <span class="pull-right poe-portPwr-width">
-<span class="portPwr">Enable</span>
-<input type="hidden" class="hidPortPwr" id="hidPortPwr" value="1">
+<span class="portPwr">Disable</span>
+<input type="hidden" class="hidPortPwr" id="hidPortPwr" value="0">
 </span>
 <span class="poe_index_li_title poe-port-index">
 <input type="hidden" class="port" value="1">
@@ -113,6 +113,15 @@
 </div>
 </div>
 <div class="hid_info_cell col-xs-12 col-sm-6">
+<div class="hid_info_title">
+<span class='hid-txt wid-full'>ml975</span>
+</div>
+<div>
+<span class="longerDetectShow">Get Value Fault</span>
+<input type="hidden" class="longerDetect" value="0">
+</div>
+</div>
+<div class="hid_info_cell col-xs-12 col-sm-12">
 <div onclick="edit_poe_port_info();" class="poe_edit_btn">
 <button name='editPot1' data-react-toolbox="button" class="toolbox_lib_button button_theme_flat button_theme_primary button_theme_mini button button_mini">
 EDIT
@@ -130,8 +139,8 @@ EDIT
 <span>802.3at</span>
 <input type="hidden" class="pwrMode" id="hidPwrMode" value="3"></span>
 <span class="pull-right poe-portPwr-width">
-<span class="portPwr">Enable</span>
-<input type="hidden" class="hidPortPwr" id="hidPortPwr" value="1">
+<span class="portPwr">Disable</span>
+<input type="hidden" class="hidPortPwr" id="hidPortPwr" value="0">
 </span>
 <span class="poe_index_li_title poe-port-index">
 <input type="hidden" class="port" value="2">
@@ -175,6 +184,15 @@ EDIT
 </div>
 </div>
 <div class="hid_info_cell col-xs-12 col-sm-6">
+<div class="hid_info_title">
+<span class='hid-txt wid-full'>ml975</span>
+</div>
+<div>
+<span class="longerDetectShow">Get Value Fault</span>
+<input type="hidden" class="longerDetect" value="0">
+</div>
+</div>
+<div class="hid_info_cell col-xs-12 col-sm-12">
 <div onclick="edit_poe_port_info();" class="poe_edit_btn">
 <button name='editPot2' data-react-toolbox="button" class="toolbox_lib_button button_theme_flat button_theme_primary button_theme_mini button button_mini">
 EDIT
@@ -192,8 +210,8 @@ EDIT
 <span>802.3at</span>
 <input type="hidden" class="pwrMode" id="hidPwrMode" value="3"></span>
 <span class="pull-right poe-portPwr-width">
-<span class="portPwr">Enable</span>
-<input type="hidden" class="hidPortPwr" id="hidPortPwr" value="1">
+<span class="portPwr">Disable</span>
+<input type="hidden" class="hidPortPwr" id="hidPortPwr" value="0">
 </span>
 <span class="poe_index_li_title poe-port-index">
 <input type="hidden" class="port" value="3">
@@ -237,6 +255,15 @@ EDIT
 </div>
 </div>
 <div class="hid_info_cell col-xs-12 col-sm-6">
+<div class="hid_info_title">
+<span class='hid-txt wid-full'>ml975</span>
+</div>
+<div>
+<span class="longerDetectShow">Get Value Fault</span>
+<input type="hidden" class="longerDetect" value="0">
+</div>
+</div>
+<div class="hid_info_cell col-xs-12 col-sm-12">
 <div onclick="edit_poe_port_info();" class="poe_edit_btn">
 <button name='editPot3' data-react-toolbox="button" class="toolbox_lib_button button_theme_flat button_theme_primary button_theme_mini button button_mini">
 EDIT
@@ -299,6 +326,15 @@ EDIT
 </div>
 </div>
 <div class="hid_info_cell col-xs-12 col-sm-6">
+<div class="hid_info_title">
+<span class='hid-txt wid-full'>ml975</span>
+</div>
+<div>
+<span class="longerDetectShow">Get Value Fault</span>
+<input type="hidden" class="longerDetect" value="0">
+</div>
+</div>
+<div class="hid_info_cell col-xs-12 col-sm-12">
 <div onclick="edit_poe_port_info();" class="poe_edit_btn">
 <button name='editPot4' data-react-toolbox="button" class="toolbox_lib_button button_theme_flat button_theme_primary button_theme_mini button button_mini">
 EDIT
@@ -361,6 +397,15 @@ EDIT
 </div>
 </div>
 <div class="hid_info_cell col-xs-12 col-sm-6">
+<div class="hid_info_title">
+<span class='hid-txt wid-full'>ml975</span>
+</div>
+<div>
+<span class="longerDetectShow">Get Value Fault</span>
+<input type="hidden" class="longerDetect" value="0">
+</div>
+</div>
+<div class="hid_info_cell col-xs-12 col-sm-12">
 <div onclick="edit_poe_port_info();" class="poe_edit_btn">
 <button name='editPot5' data-react-toolbox="button" class="toolbox_lib_button button_theme_flat button_theme_primary button_theme_mini button button_mini">
 EDIT
@@ -423,6 +468,15 @@ EDIT
 </div>
 </div>
 <div class="hid_info_cell col-xs-12 col-sm-6">
+<div class="hid_info_title">
+<span class='hid-txt wid-full'>ml975</span>
+</div>
+<div>
+<span class="longerDetectShow">Get Value Fault</span>
+<input type="hidden" class="longerDetect" value="0">
+</div>
+</div>
+<div class="hid_info_cell col-xs-12 col-sm-12">
 <div onclick="edit_poe_port_info();" class="poe_edit_btn">
 <button name='editPot6' data-react-toolbox="button" class="toolbox_lib_button button_theme_flat button_theme_primary button_theme_mini button button_mini">
 EDIT
@@ -485,6 +539,15 @@ EDIT
 </div>
 </div>
 <div class="hid_info_cell col-xs-12 col-sm-6">
+<div class="hid_info_title">
+<span class='hid-txt wid-full'>ml975</span>
+</div>
+<div>
+<span class="longerDetectShow">Get Value Fault</span>
+<input type="hidden" class="longerDetect" value="0">
+</div>
+</div>
+<div class="hid_info_cell col-xs-12 col-sm-12">
 <div onclick="edit_poe_port_info();" class="poe_edit_btn">
 <button name='editPot7' data-react-toolbox="button" class="toolbox_lib_button button_theme_flat button_theme_primary button_theme_mini button button_mini">
 EDIT
@@ -502,8 +565,8 @@ EDIT
 <span>802.3at</span>
 <input type="hidden" class="pwrMode" id="hidPwrMode" value="3"></span>
 <span class="pull-right poe-portPwr-width">
-<span class="portPwr">Disable</span>
-<input type="hidden" class="hidPortPwr" id="hidPortPwr" value="0">
+<span class="portPwr">Enable</span>
+<input type="hidden" class="hidPortPwr" id="hidPortPwr" value="1">
 </span>
 <span class="poe_index_li_title poe-port-index">
 <input type="hidden" class="port" value="8">
@@ -547,6 +610,15 @@ EDIT
 </div>
 </div>
 <div class="hid_info_cell col-xs-12 col-sm-6">
+<div class="hid_info_title">
+<span class='hid-txt wid-full'>ml975</span>
+</div>
+<div>
+<span class="longerDetectShow">Get Value Fault</span>
+<input type="hidden" class="longerDetect" value="0">
+</div>
+</div>
+<div class="hid_info_cell col-xs-12 col-sm-12">
 <div onclick="edit_poe_port_info();" class="poe_edit_btn">
 <button name='editPot8' data-react-toolbox="button" class="toolbox_lib_button button_theme_flat button_theme_primary button_theme_mini button button_mini">
 EDIT


### PR DESCRIPTION
Greetings Marin,

If merged, this pull will add the ability to manipulate "[Longer Detection Time](https://kb.netgear.com/000065624/My-Hikvision-PoE-camera-won-t-power-on-when-connected-to-my-NETGEAR-PoE-Smart-or-Plus-Switch-what-do-I-do?language=en_US)" on newer Netgear firmware for the GS305EP(P)/GS308EPP switch. 

I have omitted the short switch for this parameter as I could not find a reasonable one to use and this might be a rarely invoked command.

Leaving the setting as-is (Get Value Fault) post-upgrade caused the PoE settings UI to stop working on my end, so hopefully this saves someone from a lot of clicking..