### PR TITLE
Make token directory configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Usage: ntgrrc <command>
 Flags:
   -h, --help                  Show context-sensitive help.
       --help-all              advanced/full help
+  -d, --token-dir             directory for login token storage
   -v, --verbose               verbose log messages
   -q, --quiet                 no log messages
   -f, --output-format="md"    what output format to use [md, json]

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ type GlobalOptions struct {
 	Verbose      bool
 	Quiet        bool
 	OutputFormat OutputFormat
+	TokenDir     string
 }
 
 var cli struct {
@@ -17,6 +18,7 @@ var cli struct {
 	Verbose      bool         `help:"verbose log messages" short:"v"`
 	Quiet        bool         `help:"no log messages" short:"q"`
 	OutputFormat OutputFormat `help:"what output format to use [md, json]" enum:"md,json" default:"md" short:"f"`
+	TokenDir     string       `help:"directory to store login tokens" default:"" short:"d"`
 
 	Version VersionCommand `cmd:"" name:"version" help:"show version"`
 	Login   LoginCommand   `cmd:"" name:"login" help:"create a session for further commands (requires admin console password)"`
@@ -41,6 +43,7 @@ func main() {
 		Verbose:      cli.Verbose,
 		Quiet:        cli.Quiet,
 		OutputFormat: cli.OutputFormat,
+		TokenDir:     cli.TokenDir,
 	})
 	if err != nil {
 		fmt.Printf("Error: %s\n", err.Error())


### PR DESCRIPTION
Hi Martin,
If merged, this pull would allow the use of `-d` or `--token-dir` as an option to store the login token.

By default, the behavior does not change from pull #17 where it defaults to `/tmp`, but if using a custom token directory it must be specified each time on the command-line.

~~This also patches a small issue with new directory creation where it would be created with permissions that made the token directory inaccessible. Details are in:  https://github.com/nitram509/ntgrrc/commit/6b8d706eb2354c8bcec93f7546f5ff6aa85cc486~~ Update: On re-testing, this issue has not re-occurred.