### PR TITLE
token: Init directory with permissions for token file creation

### DIFF
--- a/token.go
+++ b/token.go
@@ -40,7 +40,7 @@ func loadToken(args *GlobalOptions, host string) (string, error) {
 
 func ensureConfigPathExists(configDir string) error {
 	dotConfigNtgrrc := dotConfigDirName(configDir)
-	err := os.MkdirAll(dotConfigNtgrrc, os.ModeDir)
+	err := os.MkdirAll(dotConfigNtgrrc, os.ModeDir|0700)
 	return err
 }
 


### PR DESCRIPTION
This pull is related to #29 and re-addresses part of the dropped commit as it is now reliably reproducible..

With only the directory bit set on initial creation, the token file cannot be written to and `ntgrrc` exits with an error.

For a quick rundown without having to do a live test against a switch, I hastily put together a small Go program to simulate the problem (if running twice, be sure to remove `/tmp/.config` manually): 
https://gist.githubusercontent.com/davidk/5d78a04bcc282bab9bc17f64fdf35cd5/raw/68579dfbf671482f30b7275d5b21378866106499/dirtest.go

I believe updating to `0700` should be appropriate, but tighter permissions can be used as well. This change should not break Windows (and Windows tests), as it does not call `umask` (which does not seem to be a requirement to resolve the issue).