### PR TITLE
Add port name field

### DIFF
--- a/poe_settings.go
+++ b/poe_settings.go
@@ -3,10 +3,11 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/PuerkitoBio/goquery"
 	"io"
 	"strconv"
 	"strings"
+
+	"github.com/PuerkitoBio/goquery"
 )
 
 type PoePortSetting struct {

--- a/poe_settings.go
+++ b/poe_settings.go
@@ -11,6 +11,7 @@ import (
 
 type PoePortSetting struct {
 	PortIndex    int8
+	PortName     string
 	PortPwr      bool
 	PwrMode      string
 	PortPrio     string
@@ -42,11 +43,12 @@ func (poe *PoeShowSettingsCommand) Run(args *GlobalOptions) error {
 }
 
 func prettyPrintSettings(format OutputFormat, settings []PoePortSetting) {
-	var header = []string{"Port ID", "Port Power", "Mode", "Priority", "Limit Type", "Limit (W)", "Type", "Longer Detection Time"}
+	var header = []string{"Port ID", "Port Name", "Port Power", "Mode", "Priority", "Limit Type", "Limit (W)", "Type", "Longer Detection Time"}
 	var content [][]string
 	for _, setting := range settings {
 		var row []string
 		row = append(row, fmt.Sprintf("%d", setting.PortIndex))
+		row = append(row, setting.PortName)
 		row = append(row, asTextPortPower(setting.PortPwr))
 		row = append(row, bidiMapLookup(setting.PwrMode, pwrModeMap))
 		row = append(row, bidiMapLookup(setting.PortPrio, portPrioMap))
@@ -91,6 +93,8 @@ func findPortSettingsInHtml(reader io.Reader) ([]PoePortSetting, error) {
 		id, _ := s.Find("input[type=hidden].port").Attr("value")
 		var id64, _ = strconv.ParseInt(id, 10, 8)
 		config.PortIndex = int8(id64)
+
+		config.PortName, _ = s.Find("input[type=hidden].portName").Attr("value")
 
 		portWr, exists := s.Find("input#hidPortPwr").Attr("value")
 		config.PortPwr = exists && portWr == "1"

--- a/poe_settings_test.go
+++ b/poe_settings_test.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	_ "embed"
+	"strings"
+	"testing"
+
 	"github.com/corbym/gocrest/has"
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
-	"strings"
-	"testing"
 )
 
 func TestFindPortConfigInHtml(t *testing.T) {
@@ -27,6 +28,9 @@ func TestFindPortConfigInHtml(t *testing.T) {
 
 	setting = settings[1]
 	then.AssertThat(t, setting.PortPwr, is.EqualTo(true))
+
+	// Tests that the space is not removed if the user has deliberately added it
+	then.AssertThat(t, setting.PortName, is.EqualTo("link to - sw128 "))
 }
 
 func TestPrettyPrintSettings(t *testing.T) {

--- a/poe_status.go
+++ b/poe_status.go
@@ -3,10 +3,11 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/PuerkitoBio/goquery"
 	"io"
 	"strconv"
 	"strings"
+
+	"github.com/PuerkitoBio/goquery"
 )
 
 type PoePortStatus struct {
@@ -135,7 +136,7 @@ func getPortWithName(str string) (int8, string) {
 	index := strings.Index(str, " - ")
 	if index >= 0 {
 		portId, _ := strconv.ParseInt(str[:index], 10, 8)
-		return int8(portId), str[index+3:]
+		return int8(portId), strings.TrimSuffix(str[index+3:], " ")
 	}
 
 	portId, _ := strconv.ParseInt(str, 10, 8)

--- a/poe_status_test.go
+++ b/poe_status_test.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	_ "embed"
+	"strings"
+	"testing"
+
 	"github.com/corbym/gocrest/has"
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
-	"strings"
-	"testing"
 )
 
 func TestFindPortStatusInHtml(t *testing.T) {
@@ -24,6 +25,11 @@ func TestFindPortStatusInHtml(t *testing.T) {
 	then.AssertThat(t, status.PowerInWatt, is.EqualTo(float32(4.4)))
 	then.AssertThat(t, status.TemperatureInCelsius, is.EqualTo(int32(30)))
 	then.AssertThat(t, status.ErrorStatus, is.EqualTo("No Error"))
+
+	// Test port name parsing and ensure it matches expected display name
+	status = statuses[1]
+	then.AssertThat(t, status.PortName, is.EqualTo("link to - sw128 "))
+
 }
 
 func TestPrettyPrintMarkdownStatus(t *testing.T) {

--- a/test-data/PoEPortConfig.cgi.html
+++ b/test-data/PoEPortConfig.cgi.html
@@ -131,8 +131,8 @@ EDIT
 </span>
 <span class="poe_index_li_title poe-port-index">
 <input type="hidden" class="port" value="2">
-<span>2</span></span></div>
-<input type="hidden" class="portName" value="">
+<span style='text-overflow:ellipsis;overflow:hidden;white-space:nowrap;width:100%;display:inline-block;'>2 - link to - sw128  </span></span></div>
+<input type="hidden" class="portName" value="link to - sw128 ">
 <div class="poe_port_info">
 <div class="hid_info_cell col-xs-12 col-sm-6">
 <div class="hid_info_title">

--- a/test-data/getPoePortStatus.cgi.html
+++ b/test-data/getPoePortStatus.cgi.html
@@ -77,7 +77,7 @@
 </span>
 <span class="poe_index_li_title poe-port-index">
 <input type="hidden" class="port" value="2">
-<span>2</span></span></div>
+<span style='text-overflow:ellipsis;overflow:hidden;white-space:nowrap;width:100%;display:inline-block;'>2 - link to - sw128  </span></span></div>
 <div class="poe_port_status">
 <div class="hid_info_cell col-xs-12 col-sm-6">
 <div class="hid_info_title">


### PR DESCRIPTION
This PR adds the ability for `ntgrrc` to return information from the port name field - this is accessible and editable in the 'home' section, under the port status drop down.

Tests have been added to confirm that ntgrrc extracts information as expected and does not remove any more information than necessary (some of the pages add an extraneous space, for instance).