### PR TITLE
port_set: Check that port name parameter is passed in before changing

### DIFF
--- a/port_set.go
+++ b/port_set.go
@@ -28,13 +28,13 @@ type Port struct {
 }
 
 type PortSettingCommand struct {
-	Address          string `required:"" help:"the Netgear switch's IP address or host name to connect to" short:"a"`
-	Ports            []int  `required:"" help:"port number (starting with 1), use multiple times for setting multiple ports at once" short:"p" name:"port"`
-	Name             string `optional:"" help:"sets the name of a port, 1-16 character limit" short:"n"`
-	Speed            string `optional:"" help:"set the speed and duplex of the port ['100M full', '100M half', '10M full', '10M half', 'Auto', 'Disable']" short:"s"`
-	IngressRateLimit string `optional:"" help:"set an incoming rate limit for the port ['1 Mbit/s', '128 Mbit/s', '16 Mbit/s', '2 Mbit/s', '256 Mbit/s', '32 Mbit/s', '4 Mbit/s', '512 Kbit/s', '512 Mbit/s', '64 Mbit/s', '8 Mbit/s', 'No Limit']" short:"i"`
-	EgressRateLimit  string `optional:"" help:"set an outgoing rate limit for the port ['1 Mbit/s', '128 Mbit/s', '16 Mbit/s', '2 Mbit/s', '256 Mbit/s', '32 Mbit/s', '4 Mbit/s', '512 Kbit/s', '512 Mbit/s', '64 Mbit/s', '8 Mbit/s', 'No Limit']" short:"o"`
-	FlowControl      string `optional:"" help:"enable/disable flow control on port ['Off', 'On']"`
+	Address          string  `required:"" help:"the Netgear switch's IP address or host name to connect to" short:"a"`
+	Ports            []int   `required:"" help:"port number (starting with 1), use multiple times for setting multiple ports at once" short:"p" name:"port"`
+	Name             *string `optional:"" help:"sets the name of a port, 1-16 character limit" short:"n"`
+	Speed            string  `optional:"" help:"set the speed and duplex of the port ['100M full', '100M half', '10M full', '10M half', 'Auto', 'Disable']" short:"s"`
+	IngressRateLimit string  `optional:"" help:"set an incoming rate limit for the port ['1 Mbit/s', '128 Mbit/s', '16 Mbit/s', '2 Mbit/s', '256 Mbit/s', '32 Mbit/s', '4 Mbit/s', '512 Kbit/s', '512 Mbit/s', '64 Mbit/s', '8 Mbit/s', 'No Limit']" short:"i"`
+	EgressRateLimit  string  `optional:"" help:"set an outgoing rate limit for the port ['1 Mbit/s', '128 Mbit/s', '16 Mbit/s', '2 Mbit/s', '256 Mbit/s', '32 Mbit/s', '4 Mbit/s', '512 Kbit/s', '512 Mbit/s', '64 Mbit/s', '8 Mbit/s', 'No Limit']" short:"o"`
+	FlowControl      string  `optional:"" help:"enable/disable flow control on port ['Off', 'On']"`
 }
 
 func (portSet *PortSettingCommand) Run(args *GlobalOptions) error {
@@ -51,7 +51,13 @@ func (portSet *PortSettingCommand) Run(args *GlobalOptions) error {
 
 		portSetting := settings[switchPort-1]
 
-		name, err := comparePortSettings(Name, portSetting.Name, portSet.Name)
+		// If the port name was not set by the user, set it to the existing name (otherwise an empty port name is always considered to be the
+		// "new" value which blanks the port name on the setting next update)
+		if portSet.Name == nil {
+			portSet.Name = &portSetting.Name
+		}
+
+		name, err := comparePortSettings(Name, portSetting.Name, *portSet.Name)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Martin,
I ran into an unexpected bug while writing documentation (with details in the commit). If you have any thoughts on what might be a more elegant solution I would be happy to implement.