### PR TITLE
Change "port status" to "port settings" and make "port set" more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,121 @@ because the token file's name is derived from the provided ```--address``` devic
 ntgrrc login --address gs305ep --password secret
 ```
 
+### show port settings
+
+Once a session is created, you can fetch port settings.
+
+#### Settings 
+
+The switch's port settings are printed in Markdown table format.
+This means, separated by | (pipe) and optional suffixes with blanks.
+
+Use the ```--output-format=json``` flag, to get JSON output instead.
+
+```ntgrrc port settings --address gs305ep```
+
+```markdown
+| Port ID | Port Name | Speed | Ingress Limit | Egress Limit | Flow Control |
+|---------|-----------|-------|---------------|--------------|--------------|
+| 1       |           | Auto  | No Limit      | No Limit     | Off          |
+| 2       |           | Auto  | No Limit      | No Limit     | On           |
+| 3       |           | Auto  | No Limit      | No Limit     | On           |
+| 4       |           | Auto  | No Limit      | No Limit     | On           |
+```
+
+### set port settings
+
+ntgrrc is able to set various parameters on switch port(s).
+
+#### Port Name
+
+To change the port name (within the switch's limit of 1-16 characters), pass the name using `-n` and the desired name in quotes. More than one port number can be provided.
+
+Use the ```--output-format=json``` flag, to get JSON output instead.
+
+```ntgrrc port set -p 1 -n 'port #1' --address gs305ep```
+
+```markdown
+| Port ID | Port Name | Speed | Ingress Limit | Egress Limit | Flow Control |
+|---------|-----------|-------|---------------|--------------|--------------|
+| 1       | port #1   | Auto  | No Limit      | No Limit     | Off          |
+
+```
+
+To clear the set name, supply an empty, but quoted string. More than one port number can be provided.
+
+```ntgrrc port set -p 1 -n '' --address gs305ep```
+
+```markdown
+| Port ID | Port Name | Speed | Ingress Limit | Egress Limit | Flow Control |
+|---------|-----------|-------|---------------|--------------|--------------|
+| 1       |           | Auto  | No Limit      | No Limit     | Off          |
+```
+
+#### Speed
+
+To change the port speed, use `-s` and the desired speed ('100M full', '100M half', '10M full', '10M half', 'Auto', 'Disable') in quotes. More than one port number can be provided.
+
+Use the ```--output-format=json``` flag, to get JSON output instead.
+
+```ntgrrc port set -p 1 -s '100M half' --address gs305ep```
+
+```markdown
+| Port ID | Port Name | Speed     | Ingress Limit | Egress Limit | Flow Control |
+|---------|-----------|-----------|---------------|--------------|--------------|
+| 1       |           | 100M half | No Limit      | No Limit     | Off          |
+```
+
+#### In Rate Limit
+
+To change the in rate limit, use `-i` and the desired rate limit ('1 Mbit/s', '128 Mbit/s', '16 Mbit/s', '2 Mbit/s', '256 Mbit/s', '32 Mbit/s', '4 Mbit/s', '512 Kbit/s', '512 Mbit/s', '64 Mbit/s', '8 Mbit/s', 'No Limit') in quotes. More than one port number can be provided.
+
+Use the ```--output-format=json``` flag, to get JSON output instead.
+
+```ntgrrc port set -p 1 -i '16 Mbit/s' --address gs305ep```
+
+```markdown
+| Port ID | Port Name | Speed | Ingress Limit | Egress Limit | Flow Control |
+|---------|-----------|-------|---------------|--------------|--------------|
+| 1       |           | Auto  | 16 Mbit/s     | No Limit     | Off          |
+```
+
+#### Out Rate Limit
+
+To change the out rate limit, use `-o` and the desired rate limit ('1 Mbit/s', '128 Mbit/s', '16 Mbit/s', '2 Mbit/s', '256 Mbit/s', '32 Mbit/s', '4 Mbit/s', '512 Kbit/s', '512 Mbit/s', '64 Mbit/s', '8 Mbit/s', 'No Limit') in quotes. More than one port number can be provided.
+
+Use the ```--output-format=json``` flag, to get JSON output instead.
+
+```ntgrrc port set -p 1 -o '16 Mbit/s' --address gs305ep```
+
+```markdown
+| Port ID | Port Name | Speed | Ingress Limit | Egress Limit | Flow Control |
+|---------|-----------|-------|---------------|--------------|--------------|
+| 1       |           | Auto  | 16 Mbit/s     | 16 Mbit/s    | Off          |
+```
+
+#### Flow Control
+
+To change the flow control setting for a port, use `--flow-control` and the desired setting ('On', 'Off') in quotes. More than one port number can be provided.
+
+Use the ```--output-format=json``` flag, to get JSON output instead.
+
+```ntgrrc port set -p 1 --flow-control 'On' --address gs305epp```
+
+```markdown
+ntgrrc port set -p 1 --flow-control 'On' --address test
+| Port ID | Port Name | Speed | Ingress Limit | Egress Limit | Flow Control |
+|---------|-----------|-------|---------------|--------------|--------------|
+| 1       |           | Auto  | 16 Mbit/s     | 16 Mbit/s    | On           |
+```
+
 ### show Power Over Ethernet (POE)
 
 Once a session is created, you can fetch POE settings and status.
 
-#### Settings 
+#### Settings
 
-The switch's settings are printed in Markdown table format.
+The switch's PoE settings are printed in Markdown table format.
 This means, separated by | (pipe) and optional suffixes with blanks.
 
 Use the ```--output-format=json``` flag, to get JSON output instead.

--- a/poe_settings.go
+++ b/poe_settings.go
@@ -63,7 +63,7 @@ func prettyPrintSettings(format OutputFormat, settings []PoePortSetting) {
 	case MarkdownFormat:
 		printMarkdownTable(header, content)
 	case JsonFormat:
-		printJsonDataTable("settings", header, content)
+		printJsonDataTable("poe_settings", header, content)
 	default:
 		panic("not implemented format: " + format)
 	}

--- a/poe_status.go
+++ b/poe_status.go
@@ -70,7 +70,7 @@ func prettyPrintStatus(format OutputFormat, statuses []PoePortStatus) {
 	case MarkdownFormat:
 		printMarkdownTable(header, content)
 	case JsonFormat:
-		printJsonDataTable("status", header, content)
+		printJsonDataTable("poe_status", header, content)
 	default:
 		panic("not implemented format: " + format)
 	}

--- a/port_set.go
+++ b/port_set.go
@@ -27,7 +27,7 @@ type Port struct {
 	FlowControl      string
 }
 
-type PortSettingCommand struct {
+type PortSetCommand struct {
 	Address          string  `required:"" help:"the Netgear switch's IP address or host name to connect to" short:"a"`
 	Ports            []int   `required:"" help:"port number (starting with 1), use multiple times for setting multiple ports at once" short:"p" name:"port"`
 	Name             *string `optional:"" help:"sets the name of a port, 1-16 character limit" short:"n"`
@@ -37,7 +37,7 @@ type PortSettingCommand struct {
 	FlowControl      string  `optional:"" help:"enable/disable flow control on port ['Off', 'On']"`
 }
 
-func (portSet *PortSettingCommand) Run(args *GlobalOptions) error {
+func (portSet *PortSetCommand) Run(args *GlobalOptions) error {
 	settings, hash, err := requestPortSettings(args, portSet.Address)
 	if err != nil {
 		return err
@@ -109,7 +109,7 @@ func (portSet *PortSettingCommand) Run(args *GlobalOptions) error {
 	}
 
 	changedPorts := collectChangedPortConfiguration(portSet.Ports, settings)
-	prettyPrintPortStatus(args.OutputFormat, changedPorts)
+	prettyPrintPortSettings(args.OutputFormat, changedPorts)
 
 	return err
 }

--- a/port_set.go
+++ b/port_set.go
@@ -156,7 +156,7 @@ func comparePortSettings(name Setting, defaultValue string, newValue string) (st
 	case EgressRateLimit:
 		outRateLimit := bidiMapLookup(newValue, portRateLimitMap)
 		if outRateLimit == "unknown" {
-			return outRateLimit, errors.New("ingress rate limit could not be set. Accepted values are: " + valuesAsString(portRateLimitMap))
+			return outRateLimit, errors.New("egress rate limit could not be set. Accepted values are: " + valuesAsString(portRateLimitMap))
 		}
 		return outRateLimit, nil
 	case FlowControl:

--- a/port_settings.go
+++ b/port_settings.go
@@ -9,43 +9,43 @@ import (
 )
 
 type PortCommand struct {
-	PortStatusCommand  PortStatusCommand  `cmd:"" name:"status" help:"show current port status" default:"1"`
-	PortSettingCommand PortSettingCommand `cmd:"" name:"set" help:"set properties for a port number"`
+	PortSettingsCommand PortSettingsCommand `cmd:"" name:"settings" help:"show switch port settings" default:"1"`
+	PortSetCommand      PortSetCommand      `cmd:"" name:"set" help:"set properties for a port number"`
 }
 
-type PortStatusCommand struct {
+type PortSettingsCommand struct {
 	Address string `required:"" help:"the Netgear switch's IP address or host name to connect to" short:"a"`
 }
 
-func (port *PortStatusCommand) Run(args *GlobalOptions) error {
+func (port *PortSettingsCommand) Run(args *GlobalOptions) error {
 
 	settings, _, err := requestPortSettings(args, port.Address)
 	if err != nil {
 		return err
 	}
 
-	prettyPrintPortStatus(args.OutputFormat, settings)
+	prettyPrintPortSettings(args.OutputFormat, settings)
 
 	return nil
 }
 
-func prettyPrintPortStatus(format OutputFormat, statuses []Port) {
+func prettyPrintPortSettings(format OutputFormat, settings []Port) {
 
 	var header = []string{"Port ID", "Port Name", "Speed", "Ingress Limit", "Egress Limit", "Flow Control"}
 	var content [][]string
 
-	for _, status := range statuses {
+	for _, setting := range settings {
 		var row []string
-		row = append(row, fmt.Sprintf("%d", status.Index))
-		row = append(row, status.Name)
-		status.Speed = bidiMapLookup(status.Speed, portSpeedMap)
-		row = append(row, status.Speed)
-		status.IngressRateLimit = bidiMapLookup(status.IngressRateLimit, portRateLimitMap)
-		row = append(row, status.IngressRateLimit)
-		status.EgressRateLimit = bidiMapLookup(status.EgressRateLimit, portRateLimitMap)
-		row = append(row, status.EgressRateLimit)
-		status.FlowControl = bidiMapLookup(status.FlowControl, portFlowControlMap)
-		row = append(row, status.FlowControl)
+		row = append(row, fmt.Sprintf("%d", setting.Index))
+		row = append(row, setting.Name)
+		setting.Speed = bidiMapLookup(setting.Speed, portSpeedMap)
+		row = append(row, setting.Speed)
+		setting.IngressRateLimit = bidiMapLookup(setting.IngressRateLimit, portRateLimitMap)
+		row = append(row, setting.IngressRateLimit)
+		setting.EgressRateLimit = bidiMapLookup(setting.EgressRateLimit, portRateLimitMap)
+		row = append(row, setting.EgressRateLimit)
+		setting.FlowControl = bidiMapLookup(setting.FlowControl, portFlowControlMap)
+		row = append(row, setting.FlowControl)
 		content = append(content, row)
 	}
 	switch format {

--- a/port_settings.go
+++ b/port_settings.go
@@ -52,7 +52,7 @@ func prettyPrintPortSettings(format OutputFormat, settings []Port) {
 	case MarkdownFormat:
 		printMarkdownTable(header, content)
 	case JsonFormat:
-		printJsonDataTable("status", header, content)
+		printJsonDataTable("port_settings", header, content)
 	default:
 		panic("not implemented format: " + format)
 	}

--- a/port_settings_test.go
+++ b/port_settings_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestFindPortSettingsInHtml(t *testing.T) {
-	portSetting, err := findPortSettingsInHtml(strings.NewReader(getPortConfigStatus))
+	portSetting, err := findPortSettingsInHtml(strings.NewReader(getPortConfigSettings))
 
 	then.AssertThat(t, err, is.Nil())
 	then.AssertThat(t, portSetting, has.Length[Port](8))
@@ -26,4 +26,4 @@ func TestFindPortSettingsInHtml(t *testing.T) {
 }
 
 //go:embed test-data/GS308EPP/dashboard.cgi.html
-var getPortConfigStatus string
+var getPortConfigSettings string


### PR DESCRIPTION
This set of commits changes `ntgrrc` CLI arguments to fall more in-line with how `poe status` and `poe settings` are currently being used and structured. `port set` code was also changed to indicate that it belongs in its own separate space.

Other minor updates:
- README.md updated (following the changed CLI convention)
- When printing JSON, there should be an indication of where the output comes from (poe settings vs port settings)